### PR TITLE
namespace update for background-geolocation

### DIFF
--- a/src/plugins/backgroundGeolocation.js
+++ b/src/plugins/backgroundGeolocation.js
@@ -5,6 +5,9 @@ angular.module('ngCordova.plugins.backgroundGeolocation', [])
 
   .factory('$cordovaBackgroundGeolocation', ['$q', '$window', function ($q, $window) {
 
+    var BackgroundGeolocation = 
+      $window.plugins.backgroundGeoLocation || $window.BackgroundGeolocation;
+
     return {
 
       init: function () {
@@ -18,10 +21,10 @@ angular.module('ngCordova.plugins.backgroundGeolocation', [])
         this.init();
         var q = $q.defer();
 
-        $window.plugins.backgroundGeoLocation.configure(
+        BackgroundGeolocation.configure(
           function (result) {
             q.notify(result);
-            $window.plugins.backgroundGeoLocation.finish();
+            BackgroundGeolocation.finish();
           },
           function (err) {
             q.reject(err);
@@ -35,7 +38,7 @@ angular.module('ngCordova.plugins.backgroundGeolocation', [])
       start: function () {
         var q = $q.defer();
 
-        $window.plugins.backgroundGeoLocation.start(
+        BackgroundGeolocation.start(
           function (result) {
             q.resolve(result);
           },
@@ -49,7 +52,7 @@ angular.module('ngCordova.plugins.backgroundGeolocation', [])
       stop: function () {
         var q = $q.defer();
 
-        $window.plugins.backgroundGeoLocation.stop(
+        BackgroundGeolocation.stop(
           function (result) {
             q.resolve(result);
           },


### PR DESCRIPTION
The BackgroundGeolocation plugin from transitorsoft was updated in 2015 such that the namespace of the plugin changed. This PR fixes the undefined error that results when ngCordova tries to implement the plugin. Although I have not tested the backwards compatibility of this change, I am confident that it should still work for anyone using an older version of the plugin.

The following PR is a reference to the upstream change
https://github.com/christocracy/cordova-plugin-background-geolocation/pull/208

I recommend not removing the plugin from ngCordova codebase because some people may still want to pay for the software and utilize this functionality. #1114 