### PR TITLE
namespace fix for bg-location

### DIFF
--- a/src/plugins/backgroundGeolocation.js
+++ b/src/plugins/backgroundGeolocation.js
@@ -5,6 +5,18 @@ angular.module('ngCordova.plugins.backgroundGeolocation', [])
 
   .factory('$cordovaBackgroundGeolocation', ['$q', '$window', function ($q, $window) {
 
+    var BackgroundGeolocation =
+      (
+        ($window.plugins && $window.plugins.backgroundGeolocation) ?
+        $window.plugins.backgroundGeoLocation :
+        undefined
+      ) ||
+      (
+        ($window.BackgroundGeolocation) ?
+        $window.BackgroundGeolocation :
+        undefined
+      ) || {};
+
     return {
 
       init: function () {
@@ -18,10 +30,10 @@ angular.module('ngCordova.plugins.backgroundGeolocation', [])
         this.init();
         var q = $q.defer();
 
-        $window.plugins.backgroundGeoLocation.configure(
+        BackgroundGeolocation.configure(
           function (result) {
             q.notify(result);
-            $window.plugins.backgroundGeoLocation.finish();
+            BackgroundGeolocation.finish();
           },
           function (err) {
             q.reject(err);
@@ -35,7 +47,7 @@ angular.module('ngCordova.plugins.backgroundGeolocation', [])
       start: function () {
         var q = $q.defer();
 
-        $window.plugins.backgroundGeoLocation.start(
+        BackgroundGeolocation.start(
           function (result) {
             q.resolve(result);
           },
@@ -49,7 +61,7 @@ angular.module('ngCordova.plugins.backgroundGeolocation', [])
       stop: function () {
         var q = $q.defer();
 
-        $window.plugins.backgroundGeoLocation.stop(
+        BackgroundGeolocation.stop(
           function (result) {
             q.resolve(result);
           },

--- a/test/mocks/toast.spec.js
+++ b/test/mocks/toast.spec.js
@@ -24,7 +24,7 @@ describe('ngCordovaMocks', function () {
       $rootScope = _$rootScope_;
     }));
 
-    it('should show a toast', function () {
+    it('should show a toast', function (done) {
 
       functionNames.forEach(function(functionName){
         $cordovaToast[functionName](message)


### PR DESCRIPTION
The BackgroundGeolocation plugin from transitorsoft was updated in 2015 such that the namespace of the plugin changed. This PR fixes the undefined error that results when ngCordova tries to implement the plugin. Although I have not tested the backwards compatibility of this change, I am confident that it should still work for anyone using an older version of the plugin.

The following PR is a reference to the upstream change
christocracy/cordova-plugin-background-geolocation#208

I recommend not removing the plugin from ngCordova codebase because some people may still want to pay for the software and utilize this functionality. #1114 